### PR TITLE
docs: fix v1.4.0 accuracy errors + document undocumented surface

### DIFF
--- a/docs/content/docs/advanced/edge.mdx
+++ b/docs/content/docs/advanced/edge.mdx
@@ -39,10 +39,14 @@ It exports exactly:
 
 | Export | Kind |
 | --- | --- |
-| `streamChat`, `generateText`, `generateObject` | functions |
+| `streamChat`, `generateText`, `generateObject`, `streamObject` | functions |
+| `stepCountIs`, `hasToolCall`, `totalTokensExceed`, `costExceeds` | functions (stop conditions) |
 | `createClient`, `resolveDependencies` | functions |
+| `agentTool` | function |
+| `AgentToolDef` | type |
+| `anthropicWebSearch`, `openaiWebSearch`, `googleSearch` | functions (server tools) |
 | `DeuzClient` | type |
-| `DeuzError`, `NotImplementedError` | error classes |
+| `DeuzError`, `NotImplementedError`, `NoObjectGeneratedError` | error classes |
 | everything from the canonical types (`Message`, `Part`, `Usage`, `StreamPart`, `LanguageModel`, `CommonCallOptions`, …) | `export type *` |
 
 ```ts title="edge bundle (guaranteed safe)"

--- a/docs/content/docs/advanced/model-registry.mdx
+++ b/docs/content/docs/advanced/model-registry.mdx
@@ -102,7 +102,7 @@ Three flags exist purely to paper over provider wire bugs. The adapters read the
 
 - **`usagePerChunk`** — Gemini's OpenAI-compat wire re-emits a full usage block on *every* streamed chunk. The adapter keeps only the last one, so `usage` reflects the final totals rather than a duplicated sum.
 - **`toolIndexAllZero`** — on that same compat wire every streaming tool-call fragment arrives with `index=0`. The adapter slots fragments by arrival position instead of trusting the index, so parallel tool calls reconstruct correctly.
-- **`samplingRestrictions`** — OpenAI Responses reasoning models (`gpt-5.4`, `o4-mini`) reject `temperature` / `topP`. When set, the adapter omits those params before sending (`max_output_tokens` is still sent, defaulting to the row's `maxOutput`).
+- **`samplingRestrictions`** — some reasoning models reject `temperature` / `topP`, so the adapter omits those params before sending. It is set on the OpenAI Responses reasoning rows (`gpt-5.4`, `o4-mini` — there `max_output_tokens` is still sent, defaulting to the row's `maxOutput`) *and* on the Anthropic flagship reasoning rows (`claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-5`, `claude-fable-5`), where the Anthropic adapter likewise strips them (as it also does whenever extended thinking is enabled).
 
 There is also a behavioral guard that is *not* a registry flag: the agentic loop stops on accumulated `tool_use` count, not on `finishReason`, because Gemini can emit `finish: stop` while tool calls are still pending. See the [tool loop](/docs/agents/tools) for that invariant.
 

--- a/docs/content/docs/advanced/resilience.mdx
+++ b/docs/content/docs/advanced/resilience.mdx
@@ -139,7 +139,7 @@ A fired timer aborts the request with a `TimeoutError` whose `layer` is `'ttft'`
 
 This distinction is deliberate and load-bearing:
 
-- A **`TimeoutError`** is a genuine failure. It surfaces as an `error` part on `fullStream`, and `usage` / `finishReason` reject with it. A `ttft` timeout occurs before any content, so it participates in pre-first-byte retry; a `total` timeout is mid-stream and final.
+- A **`TimeoutError`** is a genuine failure. It surfaces as an `error` part on `fullStream`, and `usage` / `finishReason` reject with it. Neither layer is retried. A fired timer aborts `fetch` with the `TimeoutError` as the abort reason, and the pump rethrows any `TimeoutError` straight out of the retry loop before the budget is even consulted (`inference.ts`: `if (err instanceof TimeoutError || isUserAbort(...)) throw err`). So both a `ttft` timeout (during the handshake or before the first content delta) and a `total` timeout are final failures — never retried.
 - A **user abort** (you called `controller.abort()`) is *not* an error. The pump resolves `finishReason` with `'aborted'` and resolves `usage` with the partial token counts gathered so far. No `error` part is emitted, and the abort is never retried.
 
 ```ts
@@ -234,14 +234,16 @@ interface BreakerStore {
 }
 ```
 
-The critical wiring rule is **per-client resolution (G11)**: when you use [`createClient`](/docs/core/dependencies#createclient), the breaker store is resolved **once** for the client and shared across every call. A fresh in-memory store per call could never accumulate failures and so would never trip. If you inject your own store, supply it once at the client level:
+Note: core does not currently read or write this store — it accumulates no failures and never opens or trips a breaker on its own. The seam exists so the `BreakerStore` type and its per-client wiring are locked now; today it is a hook for a caller-implemented breaker.
+
+The critical wiring rule is **per-client resolution (G11)**: when you use [`createClient`](/docs/core/dependencies#createclient), the breaker store is resolved **once** for the client and shared across every call. The per-client rule matters for any breaker you build on this seam: a fresh in-memory store per call could never accumulate state across calls. If you inject your own store, supply it once at the client level:
 
 ```ts
 import { createClient } from '@deuz-sdk/core';
 import type { BreakerStore, BreakerState } from '@deuz-sdk/core';
 
 // A custom store backed by your own state (e.g. Redis/Durable Object). Shared
-// across calls so failures accumulate (G11).
+// across calls so any state your own breaker records persists across calls (G11).
 const states = new Map<string, BreakerState>();
 const breakerStore: BreakerStore = {
   get: (key) => states.get(key),
@@ -256,7 +258,7 @@ export const deuz = createClient({
 });
 ```
 
-Both `get` and `set` may return a `Promise`, so the store can be backed by a remote/persistent service for a multi-instance deployment — share one breaker across your fleet by pointing every instance at the same backend.
+Both `get` and `set` may return a `Promise`, so the store can be backed by a remote/persistent service for a multi-instance deployment — share breaker state across your fleet by pointing every instance at the same backend.
 
 ## Related
 

--- a/docs/content/docs/agents/client-tools.mdx
+++ b/docs/content/docs/agents/client-tools.mdx
@@ -7,7 +7,7 @@ A **client tool** is a `Tool` with no `execute` function. The model can still ca
 
 ## How it works
 
-Every tool in a `ToolSet` is either a **server tool** (has `execute`, the loop runs it) or a **client tool** (no `execute`). The distinction is purely the presence of `execute`:
+Every tool in a `ToolSet` is either a **server tool** (has `execute`, the loop runs it) or a **client tool** (no `execute`). The distinction is the presence of `execute` — with one exception: a [provider-executed tool](/docs/agents/server-tools) (`type: 'provider'`) has no `execute` but is run by the provider, so it does **not** break the loop as a client tool:
 
 ```ts
 import type { ToolSet } from '@deuz-sdk/core';

--- a/docs/content/docs/agents/tool-loop.mdx
+++ b/docs/content/docs/agents/tool-loop.mdx
@@ -44,7 +44,7 @@ These options live on `CommonCallOptions`, so they work identically for `generat
 | `maxSteps` | `number` | `1` | Max model turns. The default `1` means single-turn — raise it for real tool use. |
 | `stopWhen` | `StopCondition \| StopCondition[]` | — | Extra stop predicate(s), OR-ed with `maxSteps`. |
 | `maxToolConcurrency` | `number` | `5` | Max parallel tool executions per step. |
-| `onStepFinish` | `(step: StepResult) => void` | — | Fires after each completed step. |
+| `onStepFinish` | `(step: StepResult) => void` | — | Fires after each step that made tool calls (including approval / client-tool breaks). It does **not** fire for the terminal text-only step that produces the final answer — read that from `result.steps.at(-1)` or the resolved result. |
 
 `maxSteps` counts **model turns**, not tool calls. A step that executes three tools in parallel is one step.
 
@@ -58,6 +58,10 @@ A `StopCondition` is a plain function over the loop state. The type is exported;
 export type StopCondition = (info: {
   steps: StepResult[];
   stepCount: number;
+  /** Cumulative real usage across all steps (sub-agents included). */
+  usage?: Usage;
+  /** Cumulative cost in USD — only when `deps.priceProvider` is set and a condition needs it. */
+  costUSD?: number;
 }) => boolean | Promise<boolean>;
 ```
 

--- a/docs/content/docs/cookbooks/coding-agent.mdx
+++ b/docs/content/docs/cookbooks/coding-agent.mdx
@@ -129,9 +129,14 @@ const orchestratorModel = anthropic('claude-opus-4-8');
 async function runCodingTask(task: string, controller: AbortController) {
   const result = await generateText({
     model: orchestratorModel,
-    messages: [{ role: 'user', content: task }],
-    system:
-      'You are an engineering orchestrator. Break the task into sub-tasks and delegate every file/shell/test action to the coder tool — you never touch the filesystem yourself.',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are an engineering orchestrator. Break the task into sub-tasks and delegate every file/shell/test action to the coder tool — you never touch the filesystem yourself.',
+      },
+      { role: 'user', content: task },
+    ],
     maxSteps: 30,
     signal: controller.signal,
     tools: { coder },

--- a/docs/content/docs/core/dependencies.mdx
+++ b/docs/content/docs/core/dependencies.mdx
@@ -44,6 +44,18 @@ interface Tracer {
   startSpan(name: string, attributes?: Record<string, unknown>): Span;
 }
 
+interface Span {
+  setAttribute(key: string, value: unknown): void;
+  recordException(error: unknown): void;
+  end(): void;
+}
+
+interface BreakerState {
+  failures: number;
+  openedAt?: number;
+  cooldownUntil?: number;
+}
+
 interface BreakerStore {
   get(key: string): BreakerState | undefined | Promise<BreakerState | undefined>;
   set(key: string, state: BreakerState): void | Promise<void>;
@@ -58,7 +70,7 @@ interface PriceProvider {
 }
 ```
 
-`UsageMeta` (passed to `onUsage`) carries `{ model, reason: 'finished' | 'aborted' | 'error', ttftMs? }`. `FinishMeta` (passed to `onFinish`) carries `{ model, finishReason }`.
+`UsageMeta` (passed to `onUsage`) carries `{ model, reason: 'finished' | 'aborted' | 'error', ttftMs?, agentPath? }` — `agentPath` (e.g. `['researcher']`) is set when the usage originates from an `agentTool` sub-agent loop, so metering can attribute cost per sub-agent. `FinishMeta` (passed to `onFinish`) carries `{ model, finishReason }`.
 
 ### Where `deps` lives
 

--- a/docs/content/docs/core/generate-object.mdx
+++ b/docs/content/docs/core/generate-object.mdx
@@ -67,7 +67,7 @@ In tool mode, the payload is collected from the **first** tool call's accumulate
 
 ### Special case: Anthropic + extended thinking (the G3 rule)
 
-Anthropic rejects a forced `tool_choice` while extended thinking is enabled (HTTP 400). So when the model is Anthropic, reasoning is supported, and `effort` is set to anything other than `'none'`, `generateObject` overrides a would-be `tool` strategy to `json` automatically. You do not need to set `mode` yourself for this case.
+Anthropic rejects a forced `tool_choice` while extended thinking is enabled (HTTP 400). So when the model is Anthropic and extended thinking is on, `generateObject` overrides a would-be `tool` strategy to `json` automatically. Thinking counts as on either when `effort` is set to anything other than `'none'`, **or** unconditionally for adaptive-thinking flagship models whose thinking can't be disabled (registry `effortWire: 'output_config'` — e.g. `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4-7`). For those models the override fires even with `effort` unset or `'none'`. You do not need to set `mode` yourself for this case.
 
 ## Repair retry and failure
 
@@ -208,5 +208,5 @@ const { object } = await generateObject({
 ## Notes
 
 - API keys are read from `process.env` at the application layer and passed into the provider factory. The SDK core never reads environment variables itself.
-- Reasoning controls (`effort`) and sampling params from `CommonCallOptions` apply here too. On Anthropic, setting `effort` other than `'none'` forces json mode (see the G3 rule above).
+- Reasoning controls (`effort`) and sampling params from `CommonCallOptions` apply here too. On Anthropic, extended thinking forces json mode over a `tool` strategy — either when `effort` is set to something other than `'none'`, or unconditionally on adaptive-thinking flagship models (`effortWire: 'output_config'`, e.g. `claude-opus-4-8`) whose thinking can't be turned off (see the G3 rule above).
 - For streaming free-form text see [streamChat](/docs/core/stream-chat); for tool-using agentic loops see [generateText](/docs/core/generate-text).

--- a/docs/content/docs/core/generate-text.mdx
+++ b/docs/content/docs/core/generate-text.mdx
@@ -27,7 +27,7 @@ const result = await generateText(options);
 | `maxOutputTokens` | `number` | provider | Cap on generated tokens. |
 | `topP` | `number` | provider | Nucleus sampling. |
 | `stopSequences` | `string[]` | — | Hard stop strings. |
-| `effort` | `'none' \| 'low' \| 'medium' \| 'high'` | — | Canonical reasoning effort; each adapter maps it to its own unit. |
+| `effort` | `'none' \| 'low' \| 'medium' \| 'high' \| 'xhigh' \| 'max'` | — | Canonical reasoning effort; each adapter maps it to its own unit (`'xhigh'`/`'max'` clamp down on wires that lack them). |
 | `signal` | `AbortSignal` | — | Cancellation; propagated to the underlying fetch and to tool `execute`. |
 | `maxRetries` | `number` | `2` | Pre-first-byte retries only. |
 | `headers` | `Record<string, string>` | — | Extra request headers. |
@@ -44,6 +44,11 @@ Agentic options (only meaningful with `tools`):
 | `stopWhen` | `StopCondition \| StopCondition[]` | — | Extra stop predicate(s), OR-ed with `maxSteps`. |
 | `maxToolConcurrency` | `number` | `5` | Max parallel tool executions per step. |
 | `onStepFinish` | `(step: StepResult) => void` | — | Fires after each completed step. |
+| `prepareStep` | `(ctx) => PrepareStepResult \| undefined \| Promise<…>` | — | Pre-step hook run before every model call (after compaction). Return per-step overrides to rewrite `messages`, swap the `model`, restrict `activeTools`, or override `toolChoice` for that step. |
+| `compaction` | `'auto' \| CompactionPolicy` | off | Opt-in automatic layered context compaction for the loop. Pruning is free; the summarize layer costs one extra model call whose usage counts toward the total. History stays immutable. |
+| `activeTools` | `string[]` | — | Static tool filter: only these `tools` keys are sent to the model across all steps; unknown names log a warning and are ignored. `prepareStep`'s `activeTools` overrides it per step. |
+| `approveToolCall` | `(call, ctx) => boolean \| Promise<boolean>` | — | Server-mode approval gate for `needsApproval` tools; return `false` (or throw) to deny — denials become an `is_error` tool result and the loop continues. |
+| `approvalResponses` | `ToolApprovalResponse[]` | — | Resume after a client-mode break: verdicts for the trailing assistant turn's pending calls. Unmatched pending calls are denied by default. |
 
 ## Result shape
 
@@ -56,6 +61,7 @@ interface GenerateTextResult {
   steps?: StepResult[];
   toolCalls?: ToolCall[];
   toolResults?: ToolResult[];
+  pendingApprovals?: ToolApprovalRequest[];
 }
 ```
 
@@ -68,6 +74,7 @@ interface GenerateTextResult {
 | `steps` | `StepResult[]` | with tools | Per-step breakdown. **`undefined` on a single-turn call** (no `tools`). |
 | `toolCalls` | `ToolCall[]` | with tools | Convenience: the last tool-calling step's calls. |
 | `toolResults` | `ToolResult[]` | with tools | Convenience: that step's results. |
+| `pendingApprovals` | `ToolApprovalRequest[]` | client-mode approval break | Calls awaiting a verdict when a `needsApproval` tool broke the loop; resume by calling again with `approvalResponses`. |
 
 `response.messages` only contains the *new* turns this call produced — append them to your prior `messages` to continue the conversation.
 
@@ -195,6 +202,22 @@ for (const step of result.steps ?? []) {
 
 `stopWhen` adds predicate(s) that are OR-ed with `maxSteps`. A `StopCondition` is a function over the loop state; return `true` to stop after the current step.
 
+The SDK also ships four ready-made stop conditions you can import from `@deuz-sdk/core` instead of writing your own: `stepCountIs(n)`, `hasToolCall(name)`, `totalTokensExceed(n)`, and `costExceeds(usd)`. The last two read the real provider-reported usage accumulated across all steps; `costExceeds` needs `deps.priceProvider` injected (without one it warns once and never fires).
+
+```ts
+import { stepCountIs, totalTokensExceed } from '@deuz-sdk/core';
+
+// Stop at 10 steps or once accumulated usage crosses 50k tokens.
+const result = await generateText({
+  model: anthropic('claude-opus-4-8'),
+  messages: [{ role: 'user', content: 'Plan my trip.' }],
+  stopWhen: [stepCountIs(10), totalTokensExceed(50_000)],
+  tools: { /* … */ },
+});
+```
+
+You can also write a custom `StopCondition`:
+
 ```ts
 import type { StopCondition } from '@deuz-sdk/core';
 
@@ -230,6 +253,13 @@ const first = await generateText({
 messages = [...messages, ...first.response.messages];
 // next turn reuses the full, stable history (prompt-cache friendly)
 ```
+
+### Approving tool calls
+
+A tool marked `needsApproval` is gated before it runs. There are two modes:
+
+- **Server mode** — pass `approveToolCall`. The loop calls it for each gated tool and runs the call only if it returns `true`; returning `false` (or throwing) denies it, and the denial is fed back as an `is_error` tool result so the loop continues.
+- **Client mode** — omit `approveToolCall`. A gated call breaks the loop and is returned in `result.pendingApprovals`. Collect verdicts from your user, then call `generateText` again with the same appended history plus `approvalResponses` to resume; any pending call without a matching response is denied by default.
 
 ## Loop guarantees
 

--- a/docs/content/docs/core/messages.mdx
+++ b/docs/content/docs/core/messages.mdx
@@ -24,6 +24,8 @@ const messages: Message[] = [
 
 Internally, string content is coerced to a single `TextPart` and author order is preserved. The two forms above are equivalent.
 
+A `Message` may also carry an optional `providerMetadata?: Record<string, unknown>` — message-level provider round-trip data (e.g. OpenAI Responses' `{ openai: { phase } }`). It is additive and normally set and round-tripped by the SDK (it appears on the assistant messages in `response.messages`), not something you hand-author.
+
 ### Roles
 
 | Role | Use |

--- a/docs/content/docs/core/stream-chat.mdx
+++ b/docs/content/docs/core/stream-chat.mdx
@@ -47,8 +47,10 @@ function streamChat(options: StreamChatOptions): StreamChatResult;
 | `maxOutputTokens` | `number` | — | Cap on generated tokens. |
 | `topP` | `number` | — | Nucleus sampling. |
 | `stopSequences` | `string[]` | — | Stop strings. |
-| `effort` | `'none' \| 'low' \| 'medium' \| 'high'` | — | Canonical reasoning effort; each adapter maps it to its own unit. |
+| `effort` | `'none' \| 'low' \| 'medium' \| 'high' \| 'xhigh' \| 'max'` | — | Canonical reasoning effort; each adapter maps it to its own unit. `'xhigh'` (Anthropic 4.7+/OpenAI) and `'max'` (Anthropic 5.x) clamp down on wires that lack them. |
 | `responseFormat` | `'text' \| 'json'` | `'text'` | Free-form text vs. JSON mode. For schema-validated output use [generateObject](/docs/core/generate-object). |
+| `providerOptions` | `{ [provider]: Record<string, unknown> }` | — | Per-provider escape hatch, keyed by the model's provider name (e.g. `{ openai: { service_tier: 'flex' } }`, `{ google: { cachedContent } }`). Shallow top-level request-body fields merged into the wire; canonical fields the adapter sets always win. |
+| `promptCaching` | `'auto' \| 'auto-1h'` | — | One-flag prompt caching, effective only on Anthropic caching-capable models (other providers cache implicitly and ignore it). `'auto-1h'` uses the 1-hour TTL. |
 | `tools` | `ToolSet` | — | Enables the agentic loop. See [Tool Loop](/docs/agents/tool-loop). |
 | `toolChoice` | `ToolChoice` | — | Force / disable / pick a tool. |
 | `maxSteps` | `number` | `1` | Max model turns in the agentic loop. |
@@ -83,7 +85,7 @@ interface StreamChatResult {
 | `type` | Shape | Emitted |
 | --- | --- | --- |
 | `text-delta` | `{ text }` | Assistant text fragment. |
-| `reasoning-delta` | `{ text, signature? }` | Extended-thinking / reasoning fragment. |
+| `reasoning-delta` | `{ text, signature?, encrypted? }` | Extended-thinking / reasoning fragment. When `encrypted` is true, `text` is an opaque encrypted reasoning payload (OpenAI Responses) — do not render it as thinking text. |
 | `tool-call-delta` | `{ id, name?, argsTextDelta, providerMetadata? }` | Raw tool-args JSON fragment — accumulate as string, parse once at block end. |
 | `source` | `{ id, url?, title? }` | Citation / grounding source. |
 | `finish` | `{ usage, finishReason }` | Terminal part of a single turn. |
@@ -92,8 +94,11 @@ interface StreamChatResult {
 | `step-finish` | `{ stepIndex, finishReason, usage }` | Agentic loop: a step ended. |
 | `tool-call` | `{ toolCallId, toolName, input }` | Final parsed tool call. |
 | `tool-result` | `{ toolCallId, toolName, output, isError? }` | Result of executing a tool call. |
+| `tool-approval-request` | `{ approvalId, toolCallId, toolName, input }` | A tool call awaiting client-mode approval (`needsApproval` triggered, no `approveToolCall` supplied); the loop breaks after emitting these — resume via `approvalResponses`. |
+| `compaction` | `{ layer, tokensBefore, tokensAfter }` | Automatic context compaction ran before a step; token counts are estimates. Only when `compaction` is enabled in the agentic loop. |
+| `sub-agent` | `{ agentPath, part }` | A sub-agent's (`agentTool`) own canonical part forwarded live into the parent stream. |
 
-`step-*`, `tool-call`, and `tool-result` only appear when `tools` are provided.
+`step-*`, `tool-call`, `tool-result`, and `tool-approval-request` only appear when `tools` are provided.
 
 ## G2: never throws synchronously
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: A pure, web-first, multi-provider TypeScript AI SDK with zero runtime dependencies and one canonical streaming wire.
+icon: BookOpen
 ---
 
 `@deuz-sdk/core` is a from-scratch TypeScript AI SDK that talks to Anthropic, OpenAI, xAI Grok, Google Gemini, Vertex AI, and Yunwu through **one canonical streaming protocol**. It depends on no other AI SDK, ships **zero runtime dependencies**, and runs anywhere `fetch` runs — Node, Deno, Bun, and Vercel/Cloudflare Edge. Use it when you want full control over the wire, deterministic and replayable behavior, and no vendor lock-in at the streaming or UI layer.
@@ -13,7 +14,7 @@ Requires **Node >= 22**. The chat core has nothing in `dependencies`. Optional p
 
 ## Start by use case
 
-- **Build a chatbot** → [Quickstart](/docs/quickstart) + [UI streaming](/docs/modules/ui-streaming)
+- **Build a chatbot** → [Quickstart](/docs/quickstart) + [React hooks](/docs/modules/react-hooks) + [UI streaming](/docs/modules/ui-streaming)
 - **Build a coding agent** → [Tools](/docs/agents/tools) + [Sub-agents](/docs/agents/subagents) + [Budget stops](/docs/agents/tool-loop)
 - **Build a long-running agent** → [Compaction](/docs/core/compaction) + [prepareStep](/docs/agents/tool-loop)
 - **Use provider-native search** → [Provider-executed tools](/docs/agents/server-tools)
@@ -91,6 +92,8 @@ const { object } = await generateObject({
 });
 ```
 
+For streaming structured output, [streamObject](/docs/core/stream-object) returns synchronously and emits `DeepPartial<T>` via `partialObjectStream`, with a validated final `object` promise.
+
 ## Feature overview
 
 | Area | What you get | Page |
@@ -98,6 +101,7 @@ const { object } = await generateObject({
 | Streaming chat | Lazy, never-throwing canonical stream with usage and finish-reason promises | [streamChat](/docs/core/stream-chat) |
 | Text generation | Buffered single-turn or multi-step text | [generateText](/docs/core/generate-text) |
 | Structured output | Schema-typed objects (Standard Schema or JSON Schema) with auto json/tool strategy | [generateObject](/docs/core/generate-object) |
+| Structured output (streaming) | Progressive `DeepPartial<T>` via `partialObjectStream` with a validated final `object` | [streamObject](/docs/core/stream-object) |
 | Embeddings | `embed` / `embedMany` with auto-batching and concurrency caps | [Embeddings](/docs/core/embeddings) |
 | Agentic tools | Parallel, self-healing tool loop with runaway guards | [Tools](/docs/agents/tools) and [Tool loop](/docs/agents/tool-loop) |
 | Memory | mem0 extract/reconcile pipeline over a vector or Obsidian-markdown store | [Memory](/docs/modules/memory) |
@@ -106,6 +110,7 @@ const { object } = await generateObject({
 | MCP | Model Context Protocol client (HTTP/SSE edge-safe; stdio Node-only) | [MCP](/docs/modules/mcp) |
 | Image generation | Sync OpenAI-compatible generation, async Midjourney, Yunwu relay | [Image generation](/docs/modules/image-generation) |
 | UI streaming | `toDeuzStreamResponse` (server) and `readDeuzStream` (client) | [UI streaming](/docs/modules/ui-streaming) |
+| React hooks | `useChat` (client-tool round-trips + approval pauses) and `useObject` over the Deuz UI wire; React is an optional peer | [React hooks](/docs/modules/react-hooks) |
 | Middleware | `wrapModel` with logging, caching, PII redaction, injection guard | [Middleware](/docs/modules/middleware) |
 | Pricing | Optional token-to-USD cost table | [Pricing](/docs/modules/pricing) |
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Installation
 description: Install @deuz-sdk/core, check runtime requirements, and pick the optional peers and subpath exports you need.
+icon: Download
 ---
 
 `@deuz-sdk/core` is a single package with **zero runtime dependencies**. Install it, and the chat core, the agentic tool loop, streaming, and the canonical UI wire are all available out of the box. Heavier or stateful capabilities (schema-typed objects, MCP, document parsing) pull in optional peers only when you actually use them.
@@ -74,7 +75,7 @@ The root export carries the free functions, the client, errors, and all canonica
 
 | Import | Purpose |
 | --- | --- |
-| `@deuz-sdk/core` | Free functions (`streamChat`, `generateText`, `generateObject`, `embed`, `embedMany`), `createClient`, error taxonomy, pricing, middleware, all types |
+| `@deuz-sdk/core` | Free functions (`streamChat`, `generateText`, `generateObject`, `streamObject`, `embed`, `embedMany`), `createClient`, error taxonomy, pricing, middleware, all types |
 | `@deuz-sdk/core/anthropic` | Anthropic Messages provider (`createAnthropic`) |
 | `@deuz-sdk/core/openai` | OpenAI Chat Completions + Responses (`createOpenAI`, `createOpenAIResponses`) + `openaiEmbedding` |
 | `@deuz-sdk/core/xai` | xAI Grok, OpenAI-compatible (`createXai`) |

--- a/docs/content/docs/migration/from-vercel-ai-sdk.mdx
+++ b/docs/content/docs/migration/from-vercel-ai-sdk.mdx
@@ -92,6 +92,8 @@ const result = await generateText({
 
 Per-step and usage callbacks exist as call options: `onStepFinish(step)`, `onUsage(usage, meta)`, and `onFinish(meta)`. There is no separate `experimental_` namespace — these are stable fields on the call options.
 
+The AI SDK's `experimental_prepareStep` maps to the stable `prepareStep` hook. It runs before every model turn (after automatic compaction) and returns per-step overrides: `model` (per-step model routing), `activeTools` (restrict the wire-visible tools this step), `toolChoice`, and `messages`. A static, all-steps tool filter is also available as the top-level `activeTools` option.
+
 ## Code: basic stream
 
 ```ts title="before-stream.ts"
@@ -238,7 +240,7 @@ export async function POST(req: Request) {
 }
 ```
 
-Until the React hooks ship, consume the stream on the client with `readDeuzStream`:
+The [`useChat`](/docs/modules/react-hooks) / [`useObject`](/docs/modules/react-hooks) hooks (`@deuz-sdk/core/react`) consume this wire for you; to read it directly without React, use `readDeuzStream`:
 
 ```ts title="client.ts"
 import { readDeuzStream } from '@deuz-sdk/core/ui';

--- a/docs/content/docs/modules/image-generation.mdx
+++ b/docs/content/docs/modules/image-generation.mdx
@@ -208,9 +208,13 @@ const task = await imagine({
 });
 ```
 
+### blend
+
+`submitBlend` requires `base64Array` — 2-5 base64 data-URLs to blend — and accepts an optional `dimensions` (a `string`; accepted values `'PORTRAIT'`, `'SQUARE'`, `'LANDSCAPE'`) that controls the output aspect ratio.
+
 ### Webhook mode
 
-Instead of polling, pass `notifyHook` (a webhook URL) to any submit call. The relay calls that URL when the task completes, and you persist the result from your webhook handler rather than holding the request open with `waitForTask`. `submitImagine`, `submitBlend`, and `submitDescribe` all accept `notifyHook`.
+Instead of polling, pass `notifyHook` (a webhook URL) to the `submitImagine`, `submitBlend`, or `submitDescribe` calls. The relay calls that URL when the task completes, and you persist the result from your webhook handler rather than holding the request open with `waitForTask`. `submitImagine`, `submitBlend`, and `submitDescribe` all accept `notifyHook`.
 
 ```ts title="webhook.ts"
 import { submitImagine } from '@deuz-sdk/core/midjourney';

--- a/docs/content/docs/modules/mcp.mdx
+++ b/docs/content/docs/modules/mcp.mdx
@@ -158,6 +158,8 @@ const mcp = await createMcpClient({
 
 Return `{ action: 'accept', content? }`, `{ action: 'decline' }`, or `{ action: 'cancel' }`. Form-mode `content` must match `requestedSchema`. URL mode exists for sensitive flows (OAuth, payment, API keys) that must not pass through the client — treat the URL as untrusted, display the full host, and let the user decide.
 
+Passing `onElicitationRequest` at connect time is the normal path. The lower-level `registerElicitation(client, handler)` is also exported from `@deuz-sdk/core/mcp` to attach a handler to an already-connected raw MCP client (it throws if the peer is older than `^1.29.0`).
+
 ## HTTP server in a tool loop
 
 Connect to a remote MCP server, list its tools, and let the model use them. Remember to `close()`.

--- a/docs/content/docs/modules/memory.mdx
+++ b/docs/content/docs/modules/memory.mdx
@@ -66,7 +66,7 @@ import { createEmbedder } from '@deuz-sdk/core/memory';
 import { createGoogleEmbedding } from '@deuz-sdk/core/google';
 
 const google = createGoogleEmbedding({ apiKey: process.env.GOOGLE_API_KEY! });
-const embedder = createEmbedder(google('text-embedding-004'));
+const embedder = createEmbedder(google('gemini-embedding-001'));
 ```
 
 ## The MemoryStore seam
@@ -106,7 +106,7 @@ interface MemoryStore {
 | `topK` | `number` | `5` | Existing-memory retrieval breadth for reconciliation. |
 | `supersede` | `'soft' \| 'hard'` | `'hard'` | `soft` → set `invalidAt` instead of deleting (bi-temporal history). |
 | `ttlMs` | `number` | — | Absolute expiry written as `expiresAt`. |
-| `kind` | `MemoryKind` | `'semantic'` | `'episodic' \| 'semantic' \| 'working' \| 'procedural'`. |
+| `kind` | `MemoryKind` | `'semantic'` (`'episodic'` when `infer: false`) | `'episodic' \| 'semantic' \| 'working' \| 'procedural'`. |
 | `customInstructions` | `string` | — | Appended to the extraction system prompt. |
 | `customExtract` | `(messages) => MemoryFact[]` | — | Replace the LLM extraction step entirely. |
 
@@ -143,7 +143,7 @@ const llm: MemoryLLM = async ({ system, user }) => {
 
 const seams: MemorySeams = {
   store: createInMemoryMemoryStore(),
-  embedder: createEmbedder(google('text-embedding-004')),
+  embedder: createEmbedder(google('gemini-embedding-001')),
   llm,
   clock: { now: () => Date.now(), setTimeout: (fn, ms) => (setTimeout(fn, ms), () => {}) },
   generateId: () => crypto.randomUUID(),
@@ -189,7 +189,7 @@ interface MemoryQuery {
 | `dropExpired` | `boolean` | `true` | Filter out records whose `expiresAt <= clock.now()`. |
 | `scorer` | `MemoryScorer` | — | Rerank by recency · importance · relevance (`defaultMemoryScorer` provided). |
 
-`formatMemoriesForPrompt(hits, opts?)` renders the hits into a bulleted block for splicing into a system prompt (empty string when there are no hits).
+`formatMemoriesForPrompt(hits, opts?)` renders the hits into a bulleted block for splicing into a system prompt (empty string when there are no hits). `opts` accepts `header` (default `'Relevant memories:'`) and `maxChars` (hard-truncates the rendered block to bound prompt-token cost).
 
 ## Injecting memory into a chat loop
 
@@ -278,7 +278,7 @@ const llm: MemoryLLM = async ({ system, user }) => {
 const seams: MemorySeams = {
   // The vault lives on disk; commit it to git for human-auditable memory.
   store: createMarkdownMemoryStore({ dir: './data/memories' }),
-  embedder: createEmbedder(google('text-embedding-004')),
+  embedder: createEmbedder(google('gemini-embedding-001')),
   llm,
   clock: { now: () => Date.now(), setTimeout: (fn, ms) => (setTimeout(fn, ms), () => {}) },
   generateId: () => crypto.randomUUID(),

--- a/docs/content/docs/modules/pricing.mdx
+++ b/docs/content/docs/modules/pricing.mdx
@@ -18,6 +18,7 @@ interface Usage {
   cacheWriteTokens: number; // 5-minute cache writes (Anthropic)
   cacheWrite1hTokens: number; // 1-hour cache writes (Anthropic)
   audioTokens?: number; // audio in/out, when billed separately
+  serverToolUses?: number; // provider-executed tool calls (e.g. web searches), billed per call, not tokens
   totalTokens: number;
 }
 ```
@@ -51,6 +52,7 @@ const result = streamChat({
 | `model` | `string` | The model id the call ran against. |
 | `reason` | `'finished' \| 'aborted' \| 'error'` | `'aborted'` carries partial usage; `'error'` carries what was counted before the failure. |
 | `ttftMs` | `number` (optional) | Time-to-first-token in milliseconds, when measured. |
+| `agentPath` | `string[]` (optional) | Sub-agent path when the usage came from an `agentTool` loop; use it to attribute cost per sub-agent. |
 
 To attach cost, compute it inside your `onUsage` handler from the `Usage` — either with [`priceUsage`](#priceusage) directly or a [`PriceProvider`](#priceprovider-and-the-deps-seam).
 
@@ -89,6 +91,7 @@ How each bucket is priced (USD per 1,000,000 tokens):
 - `cacheWriteTokens` → `cacheWrite` rate (default: 1.25 × `input`).
 - `cacheWrite1hTokens` → `cacheWrite1h` rate (default: 2 × `input`).
 - `audioTokens` → `audio` rate (default: `input`).
+- `serverToolUses` → **not priced.** Provider-executed tool calls (e.g. web searches) are billed per call, not per token; `priceUsage`/`PRICES_2026` ignore this bucket, so add any server-tool cost separately in your app.
 
 The result is clamped to be non-negative and rounded to micro-dollars (6 decimals) to avoid float dust.
 

--- a/docs/content/docs/modules/rag.mdx
+++ b/docs/content/docs/modules/rag.mdx
@@ -81,6 +81,13 @@ console.log(doc.pages, doc.text.length);
 
 The peers are only loaded when a parser actually runs, so importing `rag/node` on the edge stays harmless until invoked.
 
+### Standalone parsing helpers
+
+The pieces the `parse` pipeline uses internally are also exported directly, for when you already have text or markup in hand:
+
+- `parseCsv(text, { delimiter? })` → `string[][]` and `csvToText(rows)` → tab/newline text (`@deuz-sdk/core/rag`) — the pure CSV state machine (RFC-style quoting), usable without going through `parse`.
+- `htmlToBlocks(html)` → `DocBlock[]` (`@deuz-sdk/core/rag/node`) — recover headings / paragraphs / list items from an HTML string.
+
 ## Chunking
 
 All three chunkers are pure and token-aware. They share `ChunkOptions`:
@@ -311,8 +318,10 @@ const context = hits.map((h) => h.text).join('\n\n---\n\n');
 
 const { text } = await generateText({
   model: createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! })('claude-opus-4-8'),
-  system: 'Answer using only the provided context. Cite nothing you cannot find there.',
-  prompt: `Context:\n${context}\n\nQuestion: ${question}`,
+  messages: [
+    { role: 'system', content: 'Answer using only the provided context. Cite nothing you cannot find there.' },
+    { role: 'user', content: `Context:\n${context}\n\nQuestion: ${question}` },
+  ],
 });
 ```
 

--- a/docs/content/docs/modules/react-hooks.mdx
+++ b/docs/content/docs/modules/react-hooks.mdx
@@ -80,7 +80,7 @@ await submit({ dish: 'menemen' });
 // object: DeepPartial<Recipe> | undefined — every field optional at every depth
 ```
 
-Each `object-delta` **replaces** `object` wholesale (no merging needed). String fields stream truncated (`'mene'` → `'menemen'`), so render defensively. Wire `error` parts and rejected fetches land in `error`; `stop()` aborts without erroring.
+Each `object-delta` **replaces** `object` wholesale (no merging needed). String fields stream truncated (`'mene'` → `'menemen'`), so render defensively. Wire `error` parts and rejected fetches land in `error`; `stop()` aborts without erroring. Like `useChat`, `useObject` also accepts `headers` (merged into the POST request) and `fetch` (an injectable transport for tests or custom auth) — e.g. `useObject<Recipe>({ api: '/api/recipe', headers: { authorization }, fetch: myFetch })`.
 
 Server side:
 

--- a/docs/content/docs/modules/ui-streaming.mdx
+++ b/docs/content/docs/modules/ui-streaming.mdx
@@ -69,6 +69,8 @@ If `response.body` is `null`, it yields nothing and returns immediately.
 | `tool-approval-response` | `approvalId: string`, `approved: boolean`, `reason?: string` | Client→server direction ONLY (declared for wire symmetry): the verdict travels in the next HTTP request body as `approvalResponses` — the server never serializes this part. |
 | `object-delta` | `object: unknown` | A `streamObject` partial (from `toDeuzObjectStreamResponse`) — each delta REPLACES the previous partial wholesale. [`useObject`](/docs/modules/react-hooks) consumes it. |
 | `source` | `id: string`, `url?: string`, `title?: string` | A cited source. |
+| `compaction` | `layer: string`, `tokensBefore: number`, `tokensAfter: number` | Automatic compaction ran before an agentic step (token counts are estimates). |
+| `sub-agent` | `agentPath: string[]`, `part: DeuzUIPart` | A sub-agent (`agentTool`) emitted a part, forwarded live into the parent stream with its path (`part` is the nested framed part). |
 | `finish` | `finishReason: FinishReason`, `usage: Usage` | Last meaningful part — the whole turn finished. |
 | `error` | `message: string` | A stream error occurred; `message` is redacted of secrets. |
 

--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -125,7 +125,7 @@ The `signature` round-trips automatically inside the agentic loop — preserve a
 
 ## Vision
 
-Pass an `image` part. The value may be a base64 string, a data URL, an `http(s)` URL, or raw `Uint8Array` bytes; `mediaType` is forwarded as the source `media_type`.
+Pass an `image` part. The value may be a base64 string, a data URL, an `http(s)` URL, or raw `Uint8Array` bytes. For base64/data-URL/`Uint8Array` images `mediaType` is forwarded as the source `media_type`; for an `http(s)` URL the media type is inferred by Anthropic from the URL (the `url` source carries no `media_type`).
 
 ```ts title="vision.ts"
 import { generateText } from '@deuz-sdk/core';

--- a/docs/content/docs/providers/google.mdx
+++ b/docs/content/docs/providers/google.mdx
@@ -80,6 +80,7 @@ Reasoning models emit a `thoughtSignature` on reasoning and tool-call parts. The
 
 ```ts
 import { generateText, googleSearch } from '@deuz-sdk/core';
+import { googleNative } from '@deuz-sdk/core/google';
 
 const res = await generateText({
   model: googleNative('gemini-3.5-flash'),
@@ -122,7 +123,7 @@ These are flagged in the capability registry and normalized before any consumer 
 
 ## Explicit caching + Files API
 
-The native adapter passes through an opaque `cachedContent` name and `fileData.fileUri` parts, but it does not create them. The `@deuz-sdk/core/google/extras` subpath is the producer side: `createGeminiCache` mints a reusable cache, and `uploadFile` pushes large media through the Files API. Both are edge-safe (`fetch` + Web APIs only) and work against AI Studio (API key) or Vertex (OAuth2 Bearer + project/location).
+The native adapter passes through an opaque `cachedContent` name and `fileData.fileUri` parts, but it does not create them. The `@deuz-sdk/core/google/extras` subpath is the producer side: `createGeminiCache` mints a reusable cache, and `uploadFile` pushes large media through the Files API. Both are edge-safe (`fetch` + Web APIs only). The cache helpers work against AI Studio (API key) or Vertex (OAuth2 Bearer + project/location); `uploadFile` (Files API) is AI Studio only — on Vertex it throws, so upload to Google Cloud Storage and pass a `gs://` fileUri instead.
 
 ### Explicit caching
 

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -12,11 +12,13 @@ import { streamChat, generateText, embed } from '@deuz-sdk/core';
 import { createOpenAI, createOpenAIResponses, createOpenAIEmbedding } from '@deuz-sdk/core/openai';
 ```
 
+The subpath also exports ready-made `openai`, `openaiResponses`, and `openaiEmbedding` singletons (each the corresponding `create*()` called with no settings) for use with client-level keys — set via `createClient({ apiKeys: … })` or a `deps.keyProvider` — since these carry no factory `apiKey` of their own.
+
 ## Which surface to use
 
 | Surface | Factory | Endpoint | Use when |
 | --- | --- | --- | --- |
-| Chat Completions | `createOpenAI` | `/chat/completions` | General chat, tools, vision, structured output. No reasoning on this wire. |
+| Chat Completions | `createOpenAI` | `/chat/completions` | General chat, tools, vision, structured output. `gpt-5.5`/`gpt-5.5-pro` also accept `reasoning_effort` here. |
 | Responses API | `createOpenAIResponses` | `/responses` | GPT-5.x and `o`-series reasoning models; typed `response.*` streaming events. |
 | Embeddings | `createOpenAIEmbedding` | `/embeddings` | `text-embedding-3-small` / `-large`. |
 
@@ -101,15 +103,15 @@ console.log(result.usage.reasoningTokens);
 
 ### Reasoning effort
 
-The canonical `effort` option is `'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'`. On the **Responses** surface it rides `reasoning: { effort }` for reasoning-capable models; `'max'` clamps to `'xhigh'`, and `'none'` omits the reasoning block entirely:
+The canonical `effort` option is `'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'`. On the **Responses** surface it rides `reasoning: { effort }` for reasoning-capable models; `'max'` clamps to `'xhigh'`, and `'none'` is sent verbatim as `reasoning: { effort: 'none' }` (a real OpenAI value that disables reasoning). The reasoning block is omitted only when `effort` is left undefined (or the model is not reasoning-capable):
 
 | `effort` value | Responses request |
 | --- | --- |
-| `'none'` | `reasoning` omitted (no reasoning block sent). |
+| `'none'` | `reasoning: { effort: 'none' }` (real OpenAI value; disables reasoning). |
 | `'low'` / `'medium'` / `'high'` / `'xhigh'` | `reasoning: { effort: <value> }`. |
 | `'max'` | clamped to `'xhigh'`. |
 
-On **Chat Completions** (GPT-5.4+ ships `reasoning_effort` there, so `gpt-5.5`/`gpt-5.5-pro` accept `effort` too), `'none'` is a real OpenAI value and is sent verbatim as `reasoning_effort: 'none'` — it is *not* omitted there. The two surfaces differ deliberately: Responses treats `'none'` as "no reasoning block", Chat Completions treats it as an explicit effort level.
+On **Chat Completions** (GPT-5.4+ ships `reasoning_effort` there, so `gpt-5.5`/`gpt-5.5-pro` accept `effort` too), `'none'` is likewise sent verbatim as `reasoning_effort: 'none'`. Both surfaces send `'none'` as an explicit effort value; the reasoning block/param is skipped only when `effort` is undefined.
 
 Reasoning models on the Responses surface have `samplingRestrictions` set, so `temperature` and `topP` are dropped for those models. `maxOutputTokens` maps to `max_output_tokens` (falling back to the model's registry `maxOutput`).
 


### PR DESCRIPTION
Audited every docs page against the shipped v1.4.0 source with an independent verification pass (durable/1.5 excluded as unimplemented). ~52 verified fixes across 24 pages, plus 4 previously-undocumented exports.

- effort enum missing 'xhigh'/'max' (generate-text, stream-chat, generate-object)
- OpenAI Responses effort:'none' is sent verbatim, not omitted
- coding-agent: generateText has no top-level `system` option -> system-role message
- rag: fix broken generateText example (top-level system/prompt -> messages)
- edge.mdx missing exports (streamObject, stop conditions, agentTool, server tools, NoObjectGeneratedError)
- memory: decommissioned text-embedding-004 -> gemini-embedding-001
- generate-text: stopWhen built-ins, prepareStep, compaction, activeTools, approval flow, pendingApprovals
- stream-chat: tool-approval-request/compaction/sub-agent parts, providerOptions, promptCaching
- resilience: breaker store is reserved (core never trips it); TTFT/total timeouts not retried
- google: uploadFile is AI-Studio-only + grounding example import; anthropic URL image media_type
- pricing/dependencies: serverToolUses bucket, agentPath on UsageMeta, Span/BreakerState shapes
- document parseCsv/csvToText/htmlToBlocks (rag) and registerElicitation (mcp)